### PR TITLE
fix: run vite in prod

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -18,6 +18,8 @@ supabase start
 if [ "$COMMAND" = "full" ]; then
   echo "Running in full mode"
 
+  sudo ss -lptn 'sport = :2730' | grep -o 'pid=[0-9]*' | sed 's/pid=//' | xargs -r kill
+
   (cd ./services/map-data-init/ && pnpm tsc && node --import=tsx --env-file=./.env.base --env-file=./.env.latvia ./src/index.ts | pino-pretty)
   (cd ./services/map-data-init/ && node --import=tsx --env-file=./.env.base --env-file=./.env.greece ./src/index.ts | pino-pretty)
   (cd ./services/map-data-init/ && node --import=tsx --env-file=./.env.base --env-file=./.env.estonia ./src/index.ts | pino-pretty)

--- a/infra/map-preview-service/Dockerfile
+++ b/infra/map-preview-service/Dockerfile
@@ -27,6 +27,7 @@ COPY ./husky.sh ./husky.sh
 COPY ./pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 RUN pnpm install
+RUN pnpm build
 
 # RUN pnpm run --filter=@ridi/map-preview-service build
 
@@ -36,4 +37,4 @@ USER nodeuser
 
 EXPOSE ${PORT}
 
-CMD ["node", "--import=tsx", "./services/map-preview-service/src/server.ts", "--dev"]
+CMD ["node", "--import=tsx", "./services/map-preview-service/src/server.ts"]

--- a/infra/map-preview-service/Dockerfile
+++ b/infra/map-preview-service/Dockerfile
@@ -27,7 +27,7 @@ COPY ./husky.sh ./husky.sh
 COPY ./pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 RUN pnpm install
-RUN pnpm build
+RUN pnpm --filter=@ridi/map-preview-service build
 
 # RUN pnpm run --filter=@ridi/map-preview-service build
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved service initialization by ensuring any processes using port 2730 are terminated before startup.
  * Updated the map preview service to build the project during Docker image creation and to run in production mode by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->